### PR TITLE
Add ModelPerformance metrics

### DIFF
--- a/src/dynamicpet/kineticmodel/__init__.py
+++ b/src/dynamicpet/kineticmodel/__init__.py
@@ -1,1 +1,3 @@
 """Kinetic model."""
+
+from .performance import ModelPerformance

--- a/src/dynamicpet/kineticmodel/performance.py
+++ b/src/dynamicpet/kineticmodel/performance.py
@@ -1,0 +1,75 @@
+"""Model performance metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+@dataclass
+class ModelPerformance:
+    """Evaluate performance of a fitted model."""
+
+    observed: ArrayLike
+    predicted: ArrayLike
+    num_parameters: int
+
+    def __post_init__(self) -> None:
+        self.observed = np.asarray(self.observed, dtype=float)
+        self.predicted = np.asarray(self.predicted, dtype=float)
+        if self.observed.shape != self.predicted.shape:
+            msg = "observed and predicted must have the same shape"
+            raise ValueError(msg)
+
+    @property
+    def residuals(self) -> np.ndarray:
+        """Get residuals."""
+        return self.observed - self.predicted
+
+    @property
+    def n(self) -> int:
+        """Number of observations."""
+        return int(self.observed.size)
+
+    @property
+    def rss(self) -> float:
+        """Residual sum of squares."""
+        return float(np.sum(self.residuals**2))
+
+    @property
+    def mse(self) -> float:
+        """Mean squared error."""
+        return self.rss / self.n
+
+    @property
+    def sigma_squared(self) -> float:
+        """Unbiased residual variance estimate."""
+        df = self.n - self.num_parameters
+        if df <= 0:
+            msg = "Degrees of freedom must be positive"
+            raise ValueError(msg)
+        return self.rss / df
+
+    @property
+    def aic(self) -> float:
+        """Akaike information criterion."""
+        return self.n * float(np.log(self.rss / self.n)) + 2 * self.num_parameters
+
+    @property
+    def fpe(self) -> float:
+        """Final prediction error."""
+        df = self.n - self.num_parameters
+        if df <= 0:
+            msg = "Degrees of freedom must be positive"
+            raise ValueError(msg)
+        return self.sigma_squared * (self.n + self.num_parameters) / df
+
+    @property
+    def coef_variation(self) -> float:
+        """Coefficient of variation of residuals."""
+        mean_obs = float(np.mean(self.observed))
+        if mean_obs == 0:
+            return np.inf
+        return float(np.sqrt(self.sigma_squared) / mean_obs)

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,35 @@
+"""Tests for ModelPerformance."""
+
+import numpy as np
+from dynamicpet.kineticmodel import ModelPerformance
+
+
+def make_perf() -> ModelPerformance:
+    observed = np.array([1.0, 2.0, 3.0])
+    predicted = np.array([1.1, 1.9, 2.8])
+    return ModelPerformance(observed, predicted, num_parameters=2)
+
+
+def test_mse() -> None:
+    perf = make_perf()
+    assert np.isclose(perf.mse, 0.02)
+
+
+def test_sigma_squared() -> None:
+    perf = make_perf()
+    assert np.isclose(perf.sigma_squared, 0.06)
+
+
+def test_aic() -> None:
+    perf = make_perf()
+    assert np.isclose(perf.aic, -7.736069016284432)
+
+
+def test_fpe() -> None:
+    perf = make_perf()
+    assert np.isclose(perf.fpe, 0.3)
+
+
+def test_coef_variation() -> None:
+    perf = make_perf()
+    assert np.isclose(perf.coef_variation, 0.12247448713915901)


### PR DESCRIPTION
## Summary
- add `ModelPerformance` in kineticmodel module
- expose `ModelPerformance` at package level
- test MSE, sigma², AIC, FPE, coefficient of variation

## Testing
- `pytest tests/test_performance.py -q`
- `pytest -q` *(fails: ProxyError while downloading test data)*

------
https://chatgpt.com/codex/tasks/task_e_6882772f0c0883309f06f9aa4adedc93