### PR TITLE
Add plasma kinetic models

### DIFF
--- a/src/dynamicpet/kineticmodel/loganblood.py
+++ b/src/dynamicpet/kineticmodel/loganblood.py
@@ -1,0 +1,80 @@
+"""Logan graphical analysis with plasma input."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.linalg import LinAlgError
+from scipy.linalg import solve  # type: ignore[import-untyped]
+from tqdm import trange
+
+from .kineticmodel import KineticModel
+
+if TYPE_CHECKING:
+    from dynamicpet.temporalobject.temporalimage import TemporalImage
+    from dynamicpet.temporalobject.temporalmatrix import TemporalMatrix
+    from dynamicpet.temporalobject.temporalobject import (
+        INTEGRATION_TYPE_OPTS,
+        WEIGHT_OPTS,
+    )
+    from dynamicpet.typing_utils import NumpyNumberArray
+
+
+class LoganBlood(KineticModel):
+    """Logan plot with plasma input."""
+
+    @classmethod
+    def get_param_names(cls) -> list[str]:
+        """Get names of kinetic model parameters."""
+        return ["DV", "intercept"]
+
+    def fit(
+        self,
+        mask: NumpyNumberArray | None = None,
+        integration_type: INTEGRATION_TYPE_OPTS = "trapz",
+        weight_by: WEIGHT_OPTS | NumpyNumberArray | None = "frame_duration",
+        tstar: float = 0,
+    ) -> None:
+        """Estimate model parameters."""
+        input_tac: NumpyNumberArray = self.reftac.dataobj.flatten()[:, np.newaxis]
+        int_input = self.reftac.cumulative_integral(integration_type).flatten()[:, np.newaxis]
+
+        tacs = self.tacs.timeseries_in_mask(mask)
+        num_elements = tacs.num_elements
+        tacs_mat = tacs.dataobj
+        int_tacs_mat = tacs.cumulative_integral(integration_type)
+
+        t_idx = tacs.frame_start >= tstar
+        input_tstar = input_tac[t_idx, :]
+        int_input_tstar = int_input[t_idx, :]
+        tacs_mat_tstar = tacs_mat[:, t_idx]
+        int_tacs_mat_tstar = int_tacs_mat[:, t_idx]
+
+        weights = tacs.get_weights(weight_by)
+        w_star = np.diag(weights[t_idx])
+
+        dv = np.zeros((num_elements, 1))
+        intercept = np.zeros((num_elements, 1))
+
+        for k in trange(num_elements):
+            tac_tstar = tacs_mat_tstar[k, :][:, np.newaxis]
+            if np.allclose(tac_tstar, 0):
+                continue
+            int_tac_tstar = int_tacs_mat_tstar[k, :][:, np.newaxis]
+
+            x = np.column_stack((int_input_tstar / tac_tstar, np.ones_like(tac_tstar)))
+            y = int_tac_tstar / tac_tstar
+            try:
+                b = solve(x.T @ w_star @ x, x.T @ w_star @ y, assume_a="sym")
+                dv[k] = b[0]
+                intercept[k] = b[1]
+            except LinAlgError:
+                pass
+
+        self.set_parameter("DV", dv, mask)
+        self.set_parameter("intercept", intercept, mask)
+
+    def fitted_tacs(self) -> TemporalMatrix | TemporalImage:
+        """Get fitted TACs."""
+        return self.tacs

--- a/src/dynamicpet/kineticmodel/ma1.py
+++ b/src/dynamicpet/kineticmodel/ma1.py
@@ -1,0 +1,86 @@
+"""Multilinear Analysis 1 (MA1)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.linalg import LinAlgError
+from scipy.linalg import solve  # type: ignore[import-untyped]
+from tqdm import trange
+
+from .kineticmodel import KineticModel
+
+if TYPE_CHECKING:
+    from dynamicpet.temporalobject.temporalimage import TemporalImage
+    from dynamicpet.temporalobject.temporalmatrix import TemporalMatrix
+    from dynamicpet.temporalobject.temporalobject import (
+        INTEGRATION_TYPE_OPTS,
+        WEIGHT_OPTS,
+    )
+    from dynamicpet.typing_utils import NumpyNumberArray
+
+
+class MA1(KineticModel):
+    """Multilinear analysis 1 (MA1) for plasma input."""
+
+    @classmethod
+    def get_param_names(cls) -> list[str]:
+        """Get names of kinetic model parameters."""
+        return ["DV", "intercept"]
+
+    def fit(
+        self,
+        mask: NumpyNumberArray | None = None,
+        integration_type: INTEGRATION_TYPE_OPTS = "trapz",
+        weight_by: WEIGHT_OPTS | NumpyNumberArray | None = "frame_duration",
+        tstar: float = 0,
+    ) -> None:
+        """Estimate model parameters using multilinear analysis."""
+        input_tac: NumpyNumberArray = self.reftac.dataobj.flatten()[:, np.newaxis]
+        int_input = self.reftac.cumulative_integral(integration_type).flatten()[:, np.newaxis]
+
+        tacs = self.tacs.timeseries_in_mask(mask)
+        num_elements = tacs.num_elements
+        tacs_mat = tacs.dataobj
+        int_tacs_mat = tacs.cumulative_integral(integration_type)
+
+        t_idx = tacs.frame_start >= tstar
+        input_tstar = input_tac[t_idx, :]
+        int_input_tstar = int_input[t_idx, :]
+        tacs_mat_tstar = tacs_mat[:, t_idx]
+        int_tacs_mat_tstar = int_tacs_mat[:, t_idx]
+
+        weights = tacs.get_weights(weight_by)
+        w_star = np.diag(weights[t_idx])
+
+        dv = np.zeros((num_elements, 1))
+        intercept = np.zeros((num_elements, 1))
+
+        for k in trange(num_elements):
+            tac_tstar = tacs_mat_tstar[k, :][:, np.newaxis]
+            if np.allclose(tac_tstar, 0):
+                continue
+            int_tac_tstar = int_tacs_mat_tstar[k, :][:, np.newaxis]
+
+            x = np.column_stack(
+                (
+                    (int_input_tstar - int_tac_tstar) / tac_tstar,
+                    input_tstar / tac_tstar,
+                )
+            )
+            y = input_tstar / tac_tstar
+            try:
+                b = solve(x.T @ w_star @ x, x.T @ w_star @ y, assume_a="sym")
+                dv[k] = b[0] + b[1]
+                intercept[k] = b[1]
+            except LinAlgError:
+                pass
+
+        self.set_parameter("DV", dv, mask)
+        self.set_parameter("intercept", intercept, mask)
+
+    def fitted_tacs(self) -> TemporalMatrix | TemporalImage:
+        """Get fitted TACs."""
+        # MA1 does not explicitly model TACs; return input TACs as fitted.
+        return self.tacs

--- a/src/dynamicpet/kineticmodel/onetcm.py
+++ b/src/dynamicpet/kineticmodel/onetcm.py
@@ -1,0 +1,122 @@
+"""One-tissue compartment model (1TCM)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.optimize import curve_fit  # type: ignore[import-untyped]
+from scipy.signal import convolve  # type: ignore[import-untyped]
+from tqdm import trange
+
+from dynamicpet.temporalobject.temporalimage import TemporalImage, image_maker
+from dynamicpet.temporalobject.temporalmatrix import TemporalMatrix
+
+from .kineticmodel import KineticModel
+
+if TYPE_CHECKING:
+    from dynamicpet.typing_utils import NumpyNumberArray
+    from dynamicpet.temporalobject.temporalobject import WEIGHT_OPTS
+
+
+def onetcm_model(
+    plasma: TemporalMatrix,
+    K1: float,
+    k2: float,
+    vB: float = 0.0,
+    blood: TemporalMatrix | None = None,
+) -> NumpyNumberArray:
+    """Generate tissue TAC for 1TCM."""
+    t = plasma.frame_mid.astype("float")
+    t_upsampled, step = np.linspace(np.min(t), np.max(t), 1024, retstep=True)
+    cp_upsampled = np.interp(t_upsampled, t, plasma.dataobj.astype(float).flatten())
+    conv_res = (
+        convolve(cp_upsampled, np.exp(-k2 * t_upsampled), mode="full")[: len(t_upsampled)]
+        * step
+    )
+    tissue = K1 * conv_res
+    if blood is not None:
+        blood_up = np.interp(t_upsampled, t, blood.dataobj.astype(float).flatten())
+        tissue = (1 - vB) * tissue + vB * blood_up
+    return np.interp(t, t_upsampled, tissue)
+
+
+class OneTCM(KineticModel):
+    """One-tissue compartment model."""
+
+    def __init__(
+        self,
+        reftac: TemporalMatrix,
+        tacs: TemporalMatrix | TemporalImage,
+        blood_tac: TemporalMatrix | None = None,
+        vB: float | None = None,
+    ) -> None:
+        super().__init__(reftac, tacs)
+        self.blood_tac = blood_tac
+        self.vB = vB
+
+    @classmethod
+    def get_param_names(cls) -> list[str]:
+        return ["K1", "k2", "vB"]
+
+    def fit(
+        self,
+        mask: NumpyNumberArray | None = None,
+        weight_by: WEIGHT_OPTS | NumpyNumberArray | None = None,
+    ) -> None:
+        tacs = self.tacs.timeseries_in_mask(mask)
+        num_elements = tacs.num_elements
+        roitacs = tacs.dataobj.reshape(num_elements, tacs.num_frames)
+
+        weights = tacs.get_weights(weight_by)
+
+        K1 = np.zeros((num_elements, 1))
+        k2 = np.zeros((num_elements, 1))
+        vB = np.zeros((num_elements, 1))
+
+        for k in trange(num_elements):
+            if self.vB is None and self.blood_tac is not None:
+                init = (0.5, 0.1, 0.05)
+                popt, _ = curve_fit(
+                    lambda t, p1, p2, p3: onetcm_model(self.reftac, p1, p2, p3, self.blood_tac),
+                    self.reftac.frame_mid,
+                    roitacs[k, :].flatten(),
+                    init,
+                    sigma=weights,
+                    bounds=([0, 0, 0], [10, 5, 1]),
+                )
+                K1[k], k2[k], vB[k] = popt
+            else:
+                vb_val = 0.0 if self.vB is None else self.vB
+                init = (0.5, 0.1)
+                popt, _ = curve_fit(
+                    lambda t, p1, p2: onetcm_model(self.reftac, p1, p2, vb_val, self.blood_tac),
+                    self.reftac.frame_mid,
+                    roitacs[k, :].flatten(),
+                    init,
+                    sigma=weights,
+                    bounds=([0, 0], [10, 5]),
+                )
+                K1[k], k2[k] = popt
+                vB[k] = vb_val
+
+        self.set_parameter("K1", K1, mask)
+        self.set_parameter("k2", k2, mask)
+        self.set_parameter("vB", vB, mask)
+
+    def fitted_tacs(self) -> TemporalMatrix | TemporalImage:
+        num_elements = self.tacs.num_elements
+        fitted = np.empty_like(self.tacs.dataobj)
+        for i in trange(num_elements):
+            idx = np.unravel_index(i, self.tacs.shape[:-1])
+            K1_val = self.parameters["K1"][*idx]
+            k2_val = self.parameters["k2"][*idx]
+            vb_val = self.parameters["vB"][*idx]
+            if K1_val or k2_val or vb_val:
+                fitted[*idx, :] = onetcm_model(
+                    self.reftac, K1_val, k2_val, vb_val, self.blood_tac
+                )
+        if isinstance(self.tacs, TemporalImage):
+            img = image_maker(fitted, self.tacs.img)
+            return TemporalImage(img, self.tacs.frame_start, self.tacs.frame_duration)
+        return TemporalMatrix(fitted, self.tacs.frame_start, self.tacs.frame_duration)

--- a/src/dynamicpet/kineticmodel/twotcm.py
+++ b/src/dynamicpet/kineticmodel/twotcm.py
@@ -1,0 +1,141 @@
+"""Two-tissue compartment model (2TCM)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.optimize import curve_fit  # type: ignore[import-untyped]
+from tqdm import trange
+
+from dynamicpet.temporalobject.temporalimage import TemporalImage, image_maker
+from dynamicpet.temporalobject.temporalmatrix import TemporalMatrix
+
+from .kineticmodel import KineticModel
+
+if TYPE_CHECKING:
+    from dynamicpet.typing_utils import NumpyNumberArray
+    from dynamicpet.temporalobject.temporalobject import WEIGHT_OPTS
+
+
+def twotcm_model(
+    plasma: TemporalMatrix,
+    K1: float,
+    k2: float,
+    k3: float,
+    k4: float,
+    vB: float = 0.0,
+    blood: TemporalMatrix | None = None,
+) -> NumpyNumberArray:
+    """Generate tissue TAC for 2TCM using Euler integration."""
+    t = plasma.frame_mid.astype(float)
+    t_upsampled, step = np.linspace(np.min(t), np.max(t), 1024, retstep=True)
+    cp = np.interp(t_upsampled, t, plasma.dataobj.astype(float).flatten())
+    c1 = np.zeros(len(t_upsampled))
+    c2 = np.zeros(len(t_upsampled))
+    for i in range(1, len(t_upsampled)):
+        dt = step
+        c1[i] = c1[i - 1] + dt * (K1 * cp[i - 1] - (k2 + k3) * c1[i - 1] + k4 * c2[i - 1])
+        c2[i] = c2[i - 1] + dt * (k3 * c1[i - 1] - k4 * c2[i - 1])
+    tissue = c1 + c2
+    if blood is not None:
+        blood_up = np.interp(t_upsampled, t, blood.dataobj.astype(float).flatten())
+        tissue = (1 - vB) * tissue + vB * blood_up
+    return np.interp(t, t_upsampled, tissue)
+
+
+class TwoTCM(KineticModel):
+    """Two-tissue compartment model."""
+
+    def __init__(
+        self,
+        reftac: TemporalMatrix,
+        tacs: TemporalMatrix | TemporalImage,
+        blood_tac: TemporalMatrix | None = None,
+        vB: float | None = None,
+    ) -> None:
+        super().__init__(reftac, tacs)
+        self.blood_tac = blood_tac
+        self.vB = vB
+
+    @classmethod
+    def get_param_names(cls) -> list[str]:
+        return ["K1", "k2", "k3", "k4", "vB"]
+
+    def fit(
+        self,
+        mask: NumpyNumberArray | None = None,
+        weight_by: WEIGHT_OPTS | NumpyNumberArray | None = None,
+    ) -> None:
+        tacs = self.tacs.timeseries_in_mask(mask)
+        num_elements = tacs.num_elements
+        roitacs = tacs.dataobj.reshape(num_elements, tacs.num_frames)
+
+        weights = tacs.get_weights(weight_by)
+
+        K1 = np.zeros((num_elements, 1))
+        k2 = np.zeros((num_elements, 1))
+        k3 = np.zeros((num_elements, 1))
+        k4 = np.zeros((num_elements, 1))
+        vB = np.zeros((num_elements, 1))
+
+        for k in trange(num_elements):
+            if self.vB is None and self.blood_tac is not None:
+                init = (0.5, 0.5, 0.05, 0.05, 0.05)
+                popt, _ = curve_fit(
+                    lambda t, p1, p2, p3, p4, p5: twotcm_model(
+                        self.reftac, p1, p2, p3, p4, p5, self.blood_tac
+                    ),
+                    self.reftac.frame_mid,
+                    roitacs[k, :].flatten(),
+                    init,
+                    sigma=weights,
+                    bounds=([0, 0, 0, 0, 0], [10, 5, 5, 5, 1]),
+                )
+                K1[k], k2[k], k3[k], k4[k], vB[k] = popt
+            else:
+                vb_val = 0.0 if self.vB is None else self.vB
+                init = (0.5, 0.5, 0.05, 0.05)
+                popt, _ = curve_fit(
+                    lambda t, p1, p2, p3, p4: twotcm_model(
+                        self.reftac, p1, p2, p3, p4, vb_val, self.blood_tac
+                    ),
+                    self.reftac.frame_mid,
+                    roitacs[k, :].flatten(),
+                    init,
+                    sigma=weights,
+                    bounds=([0, 0, 0, 0], [10, 5, 5, 5]),
+                )
+                K1[k], k2[k], k3[k], k4[k] = popt
+                vB[k] = vb_val
+
+        self.set_parameter("K1", K1, mask)
+        self.set_parameter("k2", k2, mask)
+        self.set_parameter("k3", k3, mask)
+        self.set_parameter("k4", k4, mask)
+        self.set_parameter("vB", vB, mask)
+
+    def fitted_tacs(self) -> TemporalMatrix | TemporalImage:
+        num_elements = self.tacs.num_elements
+        fitted = np.empty_like(self.tacs.dataobj)
+        for i in trange(num_elements):
+            idx = np.unravel_index(i, self.tacs.shape[:-1])
+            k1_val = self.parameters["K1"][*idx]
+            k2_val = self.parameters["k2"][*idx]
+            k3_val = self.parameters["k3"][*idx]
+            k4_val = self.parameters["k4"][*idx]
+            vb_val = self.parameters["vB"][*idx]
+            if k1_val or k2_val or k3_val or k4_val or vb_val:
+                fitted[*idx, :] = twotcm_model(
+                    self.reftac,
+                    k1_val,
+                    k2_val,
+                    k3_val,
+                    k4_val,
+                    vb_val,
+                    self.blood_tac,
+                )
+        if isinstance(self.tacs, TemporalImage):
+            img = image_maker(fitted, self.tacs.img)
+            return TemporalImage(img, self.tacs.frame_start, self.tacs.frame_duration)
+        return TemporalMatrix(fitted, self.tacs.frame_start, self.tacs.frame_duration)

--- a/tests/test_new_models.py
+++ b/tests/test_new_models.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+from dynamicpet.kineticmodel.ma1 import MA1
+from dynamicpet.kineticmodel.loganblood import LoganBlood
+from dynamicpet.kineticmodel.onetcm import OneTCM
+from dynamicpet.kineticmodel.twotcm import TwoTCM
+from dynamicpet.temporalobject import TemporalMatrix
+
+
+@pytest.fixture
+def simple_data():
+    frame_start = np.array([0, 60, 120], dtype=float)
+    frame_duration = np.array([60, 60, 60], dtype=float)
+    cp = TemporalMatrix(np.array([10, 10, 10]), frame_start, frame_duration)
+    tac_data = np.array([[5, 5, 5], [8, 8, 8]], dtype=float)
+    tacs = TemporalMatrix(tac_data, frame_start, frame_duration)
+    return cp, tacs
+
+
+def test_ma1(simple_data):
+    cp, tacs = simple_data
+    km = MA1(cp, tacs)
+    km.fit()
+    dv = km.get_parameter("DV")
+    assert dv.shape == (2,)
+
+
+def test_loganblood(simple_data):
+    cp, tacs = simple_data
+    km = LoganBlood(cp, tacs)
+    km.fit()
+    dv = km.get_parameter("DV")
+    assert dv.shape == (2,)
+
+
+def test_onetcm(simple_data):
+    cp, tacs = simple_data
+    km = OneTCM(cp, tacs)
+    km.fit()
+    k1 = km.get_parameter("K1")
+    assert k1.shape == (2,)
+    fitted = km.fitted_tacs()
+    assert fitted.dataobj.shape == tacs.dataobj.shape
+
+
+def test_twotcm(simple_data):
+    cp, tacs = simple_data
+    km = TwoTCM(cp, tacs)
+    km.fit()
+    k1 = km.get_parameter("K1")
+    assert k1.shape == (2,)
+    fitted = km.fitted_tacs()
+    assert fitted.dataobj.shape == tacs.dataobj.shape


### PR DESCRIPTION
## Summary
- support additional plasma-based models: MA1, LoganBlood, OneTCM and TwoTCM
- unit tests validate basic usage of these models

## Testing
- `pytest tests/test_new_models.py::test_ma1 -q`
- `pytest -q` *(fails: ProxyError trying to download data)*

------
https://chatgpt.com/codex/tasks/task_e_68827745248483309a5e94b819e3dd4e