### PR TITLE
Handle PETPrep frame times

### DIFF
--- a/src/dynamicpet/petbids/petbidsmatrix.py
+++ b/src/dynamicpet/petbids/petbidsmatrix.py
@@ -203,7 +203,23 @@ def load(
     with fname.open() as f:
         tsvreader = csv.reader(f, delimiter="\t")
         header = next(tsvreader)
-
     tsv = np.genfromtxt(fname, delimiter="\t", skip_header=1)
+
+    if (
+        len(header) >= 2
+        and header[0] == "FrameTimesStart"
+        and header[1] == "FrameTimesEnd"
+    ):
+        frame_start = tsv[:, 0]
+        frame_end = tsv[:, 1]
+        frame_duration = frame_end - frame_start
+
+        if "FrameTimesStart" not in json_dict:
+            json_dict["FrameTimesStart"] = frame_start.tolist()
+        if "FrameDuration" not in json_dict:
+            json_dict["FrameDuration"] = frame_duration.tolist()
+
+        tsv = tsv[:, 2:]
+        header = header[2:]
 
     return PETBIDSMatrix(tsv.T, json_dict, header)

--- a/tests/test_petbidsmatrix.py
+++ b/tests/test_petbidsmatrix.py
@@ -139,3 +139,47 @@ def test_set_timezero(pm: PETBIDSMatrix) -> None:
     assert pm.frame_start[0] == zero, (
         f"Expected {zero} frame start, got {pm.frame_start[0]}"
     )
+
+
+def test_load_petprep(tmp_path: Path) -> None:
+    """Test loading PETPrep style TSV/JSON."""
+    tsv_src = Path(
+        "data/petprep/sub-01/ses-baseline/pet/sub-01_ses-baseline_ref-cerebellum_desc-gtm_timeseries.tsv"
+    )
+    json_src = Path(
+        "data/petprep/sub-01/ses-baseline/pet/sub-01_ses-baseline_ref-cerebellum_desc-gtm_timeseries.json"
+    )
+
+    tsv = tmp_path / tsv_src.name
+    jsonfile = tmp_path / json_src.name
+    jsonfile.write_text(json_src.read_text())
+    tsv.write_text(tsv_src.read_text())
+
+    import json
+
+    data = json.loads(jsonfile.read_text())
+    data.update(
+        {
+            "TimeZero": "10:00:00",
+            "InjectionStart": 0,
+            "ScanStart": 0,
+            "TracerRadionuclide": "C11",
+            "ImageDecayCorrected": True,
+            "ImageDecayCorrectionTime": 0,
+        }
+    )
+    jsonfile.write_text(json.dumps(data))
+
+    pm = load(tsv, jsonfile)
+
+    arr = np.genfromtxt(tsv, delimiter="\t", skip_header=1)
+    frame_start_exp = arr[:, 0] / 60
+    frame_duration_exp = (arr[:, 1] - arr[:, 0]) / 60
+
+    assert np.allclose(pm.frame_start, frame_start_exp), "frame start mismatch"
+    assert np.allclose(pm.frame_duration, frame_duration_exp), "duration mismatch"
+    assert pm.elem_names == ["cerebellum"], "element names mismatch"
+    assert pm.json_dict["FrameTimesStart"] == arr[:, 0].tolist(), "json start"
+    assert pm.json_dict["FrameDuration"] == (arr[:, 1] - arr[:, 0]).tolist(), (
+        "json duration"
+    )


### PR DESCRIPTION
## Summary
- load PETPrep frame timing columns
- test PETPrep data loading

## Testing
- `ruff format src/dynamicpet/petbids/petbidsmatrix.py tests/test_petbidsmatrix.py`
- `ruff check src/dynamicpet/petbids/petbidsmatrix.py tests/test_petbidsmatrix.py`
- `PYTHONPATH=src pytest tests/test_petbidsmatrix.py::test_load_petprep -q`

------
https://chatgpt.com/codex/tasks/task_e_68827ee57dec8330b563670bf31bc733