### PR TITLE
Add plasma TAC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ After installing _Dynamic PET_ as described above, execute:
 kineticmodel PET --model SRTMZhou2003 --refmask <REFMASK> --outputdir <OUTPUTDIR> --fwhm 5
 ```
 
+For blood-based models such as MA1, provide the plasma and optional blood TACs:
+
+```console
+kineticmodel PET_TACS.tsv --model MA1 --plasmatac PLASMA.tsv --bloodtac BLOOD.tsv
+```
+
 where
 
 ```console

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,6 +40,12 @@ An optional whole blood TAC can also be provided for blood volume correction.
 These TACs should be in the same tsv format as described above and are supplied
 via the `--plasmatac` and `--bloodtac` options of `kineticmodel`.
 
+Example:
+
+```console
+kineticmodel roi_tacs.tsv --model MA1 --plasmatac plasma.tsv --bloodtac blood.tsv
+```
+
 ### Time framing information
 
 Both PET image and TAC inputs should be accompanied by a `.json` file that follows the [PET-BIDS] specification. The `.json` file is not checked for compliance with the PET-BIDS specification, but should have the following fields for full functionality with _Dynamic PET_:


### PR DESCRIPTION
## Summary
- support `--plasmatac` and `--bloodtac` in CLI
- pass plasma/blood TACs to blood-based models
- document the new options
- test MA1 CLI with plasma and blood TACs

## Testing
- `pre-commit run ruff --files src/dynamicpet/__main__.py tests/test_main.py`
- `pre-commit run ruff-format --files src/dynamicpet/__main__.py tests/test_main.py README.md docs/usage.md`
- `pytest tests/test_main.py::test_kineticmodel_ma1_plasma -q`

------
https://chatgpt.com/codex/tasks/task_e_68827ee31a6c8330bd5be79cb386ff32