### PR TITLE
Implement Logan ratio consistency check

### DIFF
--- a/tests/test_kineticmodel.py
+++ b/tests/test_kineticmodel.py
@@ -127,6 +127,22 @@ def test_logan_tm(reftac: TemporalMatrix, tacs_img: TemporalImage) -> None:
     assert dvr_img.shape == (1, 1, 2), "Mismatching shape"
 
 
+def test_logan_ratio_warning(
+    reftac: TemporalMatrix,
+    frame_start: NDArray[np.double],
+    frame_duration: NDArray[np.double],
+) -> None:
+    """Warn if tac/reftac ratio is not constant."""
+    bad_tac = TemporalMatrix(
+        np.array([[30, 60, 90, 120]], dtype=np.double),
+        frame_start,
+        frame_duration,
+    )
+    km = LRTM(reftac, bad_tac)
+    with pytest.warns(RuntimeWarning):
+        km.fit(integration_type="trapz")
+
+
 def test_patlak_tm(reftac: TemporalMatrix, tacs_img: TemporalImage) -> None:
     """Test Patlak Plot using TemporalImage."""
     km = PRTM(reftac, tacs_img)


### PR DESCRIPTION
## Summary
- verify assumption that `tac/reftac` stays constant for Logan eq.7
- warn when the ratio linearly depends on time
- test warning behaviour in `LRTM.fit`

## Testing
- `pytest tests/test_kineticmodel.py::test_logan_ratio_warning -q`
- `pytest tests/test_kineticmodel.py tests/test_kineticmodel_simulated.py tests/test_temporalmatrix.py tests/test_petbidsjson.py tests/test_petbidsmatrix.py tests/test_petbidsimage.py tests/test_performance.py tests/test_new_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688285673bd48330ae6fe7979dd7e82d