### PR TITLE
Add bloodstream input function support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Methods implemented in the CLI include:
 
 The blood-based models require a plasma TAC describing the
 radiotracer concentration in plasma. A whole blood TAC can also be
-provided for blood volume correction. These are supplied via the
-`--plasmatac` and `--bloodtac` options of the `kineticmodel` CLI.
+provided for blood volume correction. These TACs can be supplied via
+the `--plasmatac` and `--bloodtac` options or together as a
+bloodstream derivative using the `--inputfunction` option of the
+`kineticmodel` CLI.
 
 Several implementations of estimating SRTM parameters are available:
 
@@ -91,6 +93,14 @@ After installing _Dynamic PET_ as described above, execute:
 
 ```console
 kineticmodel PET --model SRTMZhou2003 --refmask <REFMASK> --outputdir <OUTPUTDIR> --fwhm 5
+```
+
+If you have a bloodstream derivative describing the arterial input
+function, you can instead run
+
+```console
+kineticmodel PET --model MA1 --refmask <REFMASK> \
+    --inputfunction <BLOODSTREAM_DERIVATIVE> --outputdir <OUTPUTDIR>
 ```
 
 where

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,10 +35,18 @@ in this file, as these will be extracted from the accompanying `.json` file (see
 ### Plasma/Blood TACs
 
 Blood-based models (MA1, Logan with plasma input, 1TCM, 2TCM) require a plasma
-TAC describing the radiotracer concentration in plasma.
-An optional whole blood TAC can also be provided for blood volume correction.
-These TACs should be in the same tsv format as described above and are supplied
-via the `--plasmatac` and `--bloodtac` options of `kineticmodel`.
+TAC describing the radiotracer concentration in plasma. An optional whole blood
+TAC can also be provided for blood volume correction. These TACs should be in
+the same tsv format as described above and are supplied via the `--plasmatac`
+and `--bloodtac` options of `kineticmodel`. Alternatively, a bloodstream
+derivative containing both curves can be specified with `--inputfunction`.
+
+Example using a bloodstream derivative:
+
+```console
+kineticmodel PET --model MA1 --refmask REFMASK \
+    --inputfunction sub-01_ses-baseline_inputfunction.tsv
+```
 
 ### Time framing information
 

--- a/src/dynamicpet/petbids/__init__.py
+++ b/src/dynamicpet/petbids/__init__.py
@@ -5,3 +5,4 @@
 from .petbidsimage import PETBIDSImage as PETBIDSImage
 from .petbidsmatrix import PETBIDSMatrix as PETBIDSMatrix
 from .petbidsmatrix import load_inputfunction as load_inputfunction
+from .bloodstream import load_inputfunction as load_bloodstream_inputfunction

--- a/src/dynamicpet/petbids/bloodstream.py
+++ b/src/dynamicpet/petbids/bloodstream.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from .petbidsjson import read_json
+from ..temporalobject.temporalmatrix import TemporalMatrix
+
+
+def load_inputfunction(filename: str | Path) -> Tuple[TemporalMatrix, TemporalMatrix]:
+    """Load arterial input function from a bloodstream derivative TSV.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Path to ``*_inputfunction.tsv`` produced by the ``bloodstream`` tool.
+
+    Returns
+    -------
+    Tuple[TemporalMatrix, TemporalMatrix]
+        ``TemporalMatrix`` instances for the metabolite corrected plasma
+        activity (``AIF`` column) and whole blood activity
+        (``whole_blood_radioactivity`` column). Times are returned in minutes.
+    """
+    fname = Path(filename)
+    jsonfile = fname.with_suffix(".json")
+    if jsonfile.exists():
+        _ = read_json(jsonfile)  # read for completeness, but not used currently
+
+    # get column indices from header
+    with fname.open() as f:
+        header = f.readline().strip().split("\t")
+    header_lower = [h.lower() for h in header]
+    time_idx = header_lower.index("time")
+    aif_idx = header_lower.index("aif")
+    wb_idx = header_lower.index("whole_blood_radioactivity")
+
+    data = np.genfromtxt(fname, delimiter="\t", skip_header=1)
+    times_sec = data[:, time_idx].astype(float)
+    aif = data[:, aif_idx].astype(float)
+    wb = data[:, wb_idx].astype(float)
+
+    frame_start = times_sec / 60.0
+    if len(frame_start) > 1:
+        frame_duration = np.diff(
+            frame_start, append=frame_start[-1] + (frame_start[-1] - frame_start[-2])
+        )
+    else:
+        frame_duration = np.array([1.0])
+
+    aif_tm = TemporalMatrix(aif, frame_start, frame_duration, [header[aif_idx]])
+    wb_tm = TemporalMatrix(wb, frame_start, frame_duration, [header[wb_idx]])
+    return aif_tm, wb_tm


### PR DESCRIPTION
## Summary
- add `--inputfunction` option for `kineticmodel`
- implement bloodstream loader for arterial input functions
- integrate new loader in CLI processing
- document new option and usage
- test CLI with bloodstream inputfunction

## Testing
- `pytest -q` *(fails: ProxyError while downloading OpenNeuro data)*

------
https://chatgpt.com/codex/tasks/task_e_68828554d5f88330935e548f964e96f1